### PR TITLE
feat: Add support for confirmAckChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ spring-cloud-stream-binder-sns lets you use [Spring Cloud Stream](https://spring
     <dependency>
         <groupId>de.idealo.spring</groupId>
         <artifactId>spring-cloud-stream-binder-sns</artifactId>
-        <version>1.0.3</version>
+        <version>1.4.3</version>
     </dependency>
 </dependencies>
 ```
@@ -17,6 +17,11 @@ spring-cloud-stream-binder-sns lets you use [Spring Cloud Stream](https://spring
 ## Usage
 
 With the library in your dependencies you can configure your Spring Cloud Stream bindings as usual. The type name for this binder is `sns`. There are no additional configuration options at the moment. The destination needs to match the topic name, the specific ARN will be looked up from the available topics in the account.
+
+You may also provide additional configuration options:
+
+- **Producers**
+    - **confirmAckChannel** - A channel to which to send positive delivery acknowledgments (aka publisher confirms). If the channel does not exist, a DirectChannel is registered with this name.  
 
 **Example Configuration:**
 
@@ -27,6 +32,10 @@ spring:
       bindings:
         someFunction-out-0:
           destination: topic-name
+      sns:
+        default:
+          producer:
+            confirmAckChannel: ack-channel-name
 ```
 
 You may also provide your own beans of `AmazonSNSAsync` to override those that are created by [spring-cloud-aws-autoconfigure](https://github.com/spring-cloud/spring-cloud-aws/tree/master/spring-cloud-aws-autoconfigure).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.idealo.spring</groupId>
     <artifactId>spring-cloud-stream-binder-sns</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <name>Spring Cloud Stream Binder for AWS SNS</name>
     <description>Allows you to use Spring Cloud Stream together with AWS SNS</description>
     <url>https://github.com/idealo/spring-cloud-stream-binder-sns</url>

--- a/src/main/java/de/idealo/spring/stream/binder/sns/config/SnsBinderConfiguration.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/config/SnsBinderConfiguration.java
@@ -1,11 +1,13 @@
 package de.idealo.spring.stream.binder.sns.config;
 
+import de.idealo.spring.stream.binder.sns.properties.SnsExtendedBindingProperties;
 import java.util.Optional;
 
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +24,7 @@ import de.idealo.spring.stream.binder.sns.provisioning.SnsStreamProvisioner;
 
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
+@EnableConfigurationProperties({ SnsExtendedBindingProperties.class })
 public class SnsBinderConfiguration {
 
     @Bean
@@ -30,8 +33,10 @@ public class SnsBinderConfiguration {
     }
 
     @Bean
-    public SnsMessageHandlerBinder snsMessageHandlerBinder(AmazonSNSAsync amazonSNS, SnsStreamProvisioner snsStreamProvisioner) {
-        return new SnsMessageHandlerBinder(amazonSNS, snsStreamProvisioner);
+    public SnsMessageHandlerBinder snsMessageHandlerBinder(AmazonSNSAsync amazonSNS,
+                                                           SnsStreamProvisioner snsStreamProvisioner,
+                                                           SnsExtendedBindingProperties snsExtendedBindingProperties) {
+        return new SnsMessageHandlerBinder(amazonSNS, snsStreamProvisioner, snsExtendedBindingProperties);
     }
 
     @Configuration

--- a/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsBindingProperties.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsBindingProperties.java
@@ -1,0 +1,28 @@
+package de.idealo.spring.stream.binder.sns.properties;
+
+import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
+
+public class SnsBindingProperties implements BinderSpecificPropertiesProvider {
+
+    private SnsConsumerProperties consumer = new SnsConsumerProperties();
+
+    private SnsProducerProperties producer = new SnsProducerProperties();
+
+    @Override
+    public SnsConsumerProperties getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(SnsConsumerProperties consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public SnsProducerProperties getProducer() {
+        return producer;
+    }
+
+    public void setProducer(SnsProducerProperties producer) {
+        this.producer = producer;
+    }
+}

--- a/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsConsumerProperties.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsConsumerProperties.java
@@ -1,0 +1,5 @@
+package de.idealo.spring.stream.binder.sns.properties;
+
+public class SnsConsumerProperties {
+
+}

--- a/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsExtendedBindingProperties.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsExtendedBindingProperties.java
@@ -1,0 +1,21 @@
+package de.idealo.spring.stream.binder.sns.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.stream.binder.AbstractExtendedBindingProperties;
+import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
+
+@ConfigurationProperties("spring.cloud.stream.sns")
+public class SnsExtendedBindingProperties extends AbstractExtendedBindingProperties<SnsConsumerProperties, SnsProducerProperties, SnsBindingProperties> {
+
+    private static final String DEFAULTS_PREFIX = "spring.cloud.stream.sns.default";
+
+    @Override
+    public String getDefaultsPrefix() {
+        return DEFAULTS_PREFIX;
+    }
+
+    @Override
+    public Class<? extends BinderSpecificPropertiesProvider> getExtendedPropertiesEntryClass() {
+        return SnsBindingProperties.class;
+    }
+}

--- a/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsProducerProperties.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/properties/SnsProducerProperties.java
@@ -1,0 +1,18 @@
+package de.idealo.spring.stream.binder.sns.properties;
+
+public class SnsProducerProperties {
+
+  /**
+   * Channel name to which to send publisher confirms (acks).
+   */
+  private String confirmAckChannel;
+
+  public String getConfirmAckChannel() {
+    return this.confirmAckChannel;
+  }
+
+  public void setConfirmAckChannel(String confirmAckChannel) {
+    this.confirmAckChannel = confirmAckChannel;
+  }
+
+}

--- a/src/main/java/de/idealo/spring/stream/binder/sns/provisioning/SnsStreamProvisioner.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/provisioning/SnsStreamProvisioner.java
@@ -1,7 +1,9 @@
 package de.idealo.spring.stream.binder.sns.provisioning;
 
-import org.springframework.cloud.stream.binder.ConsumerProperties;
-import org.springframework.cloud.stream.binder.ProducerProperties;
+import de.idealo.spring.stream.binder.sns.properties.SnsConsumerProperties;
+import de.idealo.spring.stream.binder.sns.properties.SnsProducerProperties;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
@@ -12,7 +14,7 @@ import com.amazonaws.services.sns.AmazonSNS;
 import io.awspring.cloud.core.env.ResourceIdResolver;
 import io.awspring.cloud.messaging.support.destination.DynamicTopicDestinationResolver;
 
-public class SnsStreamProvisioner implements ProvisioningProvider<ConsumerProperties, ProducerProperties> {
+public class SnsStreamProvisioner implements ProvisioningProvider<ExtendedConsumerProperties<SnsConsumerProperties>, ExtendedProducerProperties<SnsProducerProperties>> {
 
     private final DestinationResolver<String> destinationResolver;
 
@@ -21,13 +23,13 @@ public class SnsStreamProvisioner implements ProvisioningProvider<ConsumerProper
     }
 
     @Override
-    public ProducerDestination provisionProducerDestination(String name, ProducerProperties properties) {
+    public ProducerDestination provisionProducerDestination(String name, ExtendedProducerProperties<SnsProducerProperties> properties) {
         String arn = this.destinationResolver.resolveDestination(name);
         return new SnsProducerDestination(name, arn);
     }
 
     @Override
-    public ConsumerDestination provisionConsumerDestination(String name, String group, ConsumerProperties properties) {
+    public ConsumerDestination provisionConsumerDestination(String name, String group, ExtendedConsumerProperties<SnsConsumerProperties> properties) {
         throw new ProvisioningException("not supported");
     }
 }


### PR DESCRIPTION
Added support for confirmAckChannel, similar to the RabbitMQ Binder (confirmAckChannel) and the Kafka Binder (recordMetadataChannel). The acknowledge channel is crucial for a reliable message publishing confirmation.