### PR TITLE
feat: Add support for custom topic Arn resolvers

### DIFF
--- a/src/main/java/de/idealo/spring/stream/binder/sns/SnsMessageHandlerBinder.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/SnsMessageHandlerBinder.java
@@ -47,6 +47,7 @@ public class SnsMessageHandlerBinder
         SnsProducerDestination snsDestination = (SnsProducerDestination) destination;
         SnsMessageHandler snsMessageHandler = new SnsMessageHandler(amazonSNS);
         snsMessageHandler.setTopicArn(snsDestination.getArn());
+        snsMessageHandler.setTopicArnResolver(provisioningProvider.getDestinationResolver());
         snsMessageHandler.setBeanFactory(getBeanFactory());
 
         if (StringUtils.hasText(producerProperties.getExtension().getConfirmAckChannel())) {

--- a/src/main/java/de/idealo/spring/stream/binder/sns/config/SnsBinderConfiguration.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/config/SnsBinderConfiguration.java
@@ -1,5 +1,6 @@
 package de.idealo.spring.stream.binder.sns.config;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -9,11 +10,11 @@ import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.aws.support.SnsAsyncTopicArnResolver;
 
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
 
 import io.awspring.cloud.sns.core.TopicArnResolver;
-import java.util.Optional;
 
 import de.idealo.spring.stream.binder.sns.SnsMessageHandlerBinder;
 import de.idealo.spring.stream.binder.sns.health.SnsBinderHealthIndicator;
@@ -26,9 +27,9 @@ import de.idealo.spring.stream.binder.sns.provisioning.SnsStreamProvisioner;
 public class SnsBinderConfiguration {
 
     @Bean
-    public SnsStreamProvisioner provisioningProvider(SnsAsyncClient amazonSNS, Optional<TopicArnResolver> topicArnResolver) {
-        return topicArnResolver.map(SnsStreamProvisioner::new)
-                .orElseGet(() -> new SnsStreamProvisioner(amazonSNS));
+    public SnsStreamProvisioner provisioningProvider(SnsAsyncClient amazonSNS, ObjectProvider<TopicArnResolver> topicArnResolverProvider) {
+        TopicArnResolver topicArnResolver = topicArnResolverProvider.getIfAvailable(() -> new SnsAsyncTopicArnResolver(amazonSNS));
+        return new SnsStreamProvisioner(topicArnResolver);
     }
 
     @Bean

--- a/src/main/java/de/idealo/spring/stream/binder/sns/config/SnsBinderConfiguration.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/config/SnsBinderConfiguration.java
@@ -12,6 +12,9 @@ import org.springframework.context.annotation.Configuration;
 
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
 
+import io.awspring.cloud.sns.core.TopicArnResolver;
+import java.util.Optional;
+
 import de.idealo.spring.stream.binder.sns.SnsMessageHandlerBinder;
 import de.idealo.spring.stream.binder.sns.health.SnsBinderHealthIndicator;
 import de.idealo.spring.stream.binder.sns.properties.SnsExtendedBindingProperties;
@@ -23,8 +26,9 @@ import de.idealo.spring.stream.binder.sns.provisioning.SnsStreamProvisioner;
 public class SnsBinderConfiguration {
 
     @Bean
-    public SnsStreamProvisioner provisioningProvider(SnsAsyncClient amazonSNS) {
-        return new SnsStreamProvisioner(amazonSNS);
+    public SnsStreamProvisioner provisioningProvider(SnsAsyncClient amazonSNS, Optional<TopicArnResolver> topicArnResolver) {
+        return topicArnResolver.map(SnsStreamProvisioner::new)
+                .orElseGet(() -> new SnsStreamProvisioner(amazonSNS));
     }
 
     @Bean

--- a/src/main/java/de/idealo/spring/stream/binder/sns/provisioning/SnsStreamProvisioner.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/provisioning/SnsStreamProvisioner.java
@@ -6,11 +6,9 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
-import org.springframework.integration.aws.support.SnsAsyncTopicArnResolver;
 
 import io.awspring.cloud.sns.core.TopicArnResolver;
 import software.amazon.awssdk.arns.Arn;
-import software.amazon.awssdk.services.sns.SnsAsyncClient;
 
 import de.idealo.spring.stream.binder.sns.properties.SnsConsumerProperties;
 import de.idealo.spring.stream.binder.sns.properties.SnsProducerProperties;
@@ -19,12 +17,12 @@ public class SnsStreamProvisioner implements ProvisioningProvider<ExtendedConsum
 
     private final TopicArnResolver destinationResolver;
 
-    public SnsStreamProvisioner(SnsAsyncClient amazonSNS) {
-        this.destinationResolver = new SnsAsyncTopicArnResolver(amazonSNS);
-    }
-
     public SnsStreamProvisioner(TopicArnResolver topicArnResolver) {
         this.destinationResolver = topicArnResolver;
+    }
+
+    public TopicArnResolver getDestinationResolver(){
+        return this.destinationResolver;
     }
 
     @Override

--- a/src/main/java/de/idealo/spring/stream/binder/sns/provisioning/SnsStreamProvisioner.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sns/provisioning/SnsStreamProvisioner.java
@@ -23,6 +23,10 @@ public class SnsStreamProvisioner implements ProvisioningProvider<ExtendedConsum
         this.destinationResolver = new SnsAsyncTopicArnResolver(amazonSNS);
     }
 
+    public SnsStreamProvisioner(TopicArnResolver topicArnResolver) {
+        this.destinationResolver = topicArnResolver;
+    }
+
     @Override
     public ProducerDestination provisionProducerDestination(String name, ExtendedProducerProperties<SnsProducerProperties> properties) {
         Arn arn = this.destinationResolver.resolveTopicArn(name);


### PR DESCRIPTION
Currently, the implementation of `SnsStreamProvisioner` under the hood is using  `org.springframework.integration.aws.support.SnsAsyncTopicArnResolver` which is using `SNS:CreateTopic` operation to resolve topic ARN. In some cases apps could not have that permission (for security reasons) so it would be nice to provide a way to resolve ARN in different way (like by using `io.awspring.cloud.sns.core.TopicsListingTopicArnResolver`.

Proposed PR is adding such capability.